### PR TITLE
[2주차/심화] API 스펙 작성

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,9 @@ dependencies {
 	testImplementation("org.testcontainers:junit-jupiter")
 	testImplementation("org.testcontainers:mysql")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+
+	// Swagger
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
@@ -1,0 +1,10 @@
+package kr.hhplus.be.server.controller
+
+object UserApiErrorCode {
+    const val NOT_FOUND_USER_CODE: String = """{"code":"NOT_FOUND_USER"}"""
+}
+
+object BalanceApiErrorCode {
+    const val NOT_FOUND_BALANCE_CODE: String = """{"code":"NOT_FOUND_BALANCE"}"""
+    const val EXCEED_MAX_BALANCE_CODE: String = """{"code":"EXCEED_MAX_BALANCE"}"""
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
@@ -6,9 +6,12 @@ object BalanceApiErrorCode {
 }
 
 object CouponErrorCode {
+    const val ALREADY_HAS_COUPON_CODE: String = """{"code":"ALREADY_HAS_COUPON"}"""
     const val ALREADY_USED_COUPON_CODE: String = """{"code":"ALREADY_USED_COUPON"}"""
     const val EXPIRED_COUPON_CODE: String = """{"code":"EXPIRED_COUPON"}"""
     const val NOT_FOUND_COUPON_CODE: String = """{"code":"NOT_FOUND_COUPON"}"""
+    const val OUT_OF_STOCK_COUPON_CODE: String = """{"code":"OUT_OF_STOCK_COUPON"}"""
+    const val INVALID_STATE_COUPON_CODE: String = """{"code":"INVALID_STATE_COUPON"}"""
 }
 
 object OrderErrorCode {

--- a/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
@@ -5,7 +5,16 @@ object BalanceApiErrorCode {
     const val EXCEED_MAX_BALANCE_CODE: String = """{"code":"EXCEED_MAX_BALANCE"}"""
 }
 
+object CouponErrorCode {
+    const val ALREADY_USED_COUPON_CODE: String = """{"code":"ALREADY_USED_COUPON"}"""
+    const val EXPIRED_COUPON_CODE: String = """{"code":"EXPIRED_COUPON"}"""
+    const val NOT_FOUND_COUPON_CODE: String = """{"code":"NOT_FOUND_COUPON"}"""
+}
+
 object OrderErrorCode {
+    const val EXPIRED_ORDER_CODE: String = """{"code":"EXPIRED_ORDER"}"""
+    const val ALREADY_PAID_ORDER_CODE: String = """{"code":"ALREADY_PAID_ORDER"}"""
+    const val NOT_FOUND_ORDER_CODE: String = """{"code":"NOT_FOUND_ORDER"}"""
     const val INVALID_ORDER_PRICE_CODE : String = """{"code":"INVALID_ORDER_PRICE"}"""
     const val OUT_OF_PRODUCT_STOCK_CODE : String = """{"code":"OUT_OF_PRODUCT_STOCK"}"""
 }

--- a/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/ApiErrorCode.kt
@@ -1,10 +1,18 @@
 package kr.hhplus.be.server.controller
 
-object UserApiErrorCode {
-    const val NOT_FOUND_USER_CODE: String = """{"code":"NOT_FOUND_USER"}"""
-}
-
 object BalanceApiErrorCode {
     const val NOT_FOUND_BALANCE_CODE: String = """{"code":"NOT_FOUND_BALANCE"}"""
     const val EXCEED_MAX_BALANCE_CODE: String = """{"code":"EXCEED_MAX_BALANCE"}"""
 }
+
+object OrderErrorCode {
+    const val INVALID_ORDER_PRICE_CODE : String = """{"code":"INVALID_ORDER_PRICE"}"""
+    const val OUT_OF_PRODUCT_STOCK_CODE : String = """{"code":"OUT_OF_PRODUCT_STOCK"}"""
+}
+
+
+object UserApiErrorCode {
+    const val NOT_FOUND_USER_CODE: String = """{"code":"NOT_FOUND_USER"}"""
+}
+
+

--- a/src/main/kotlin/kr/hhplus/be/server/controller/ErrorResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/ErrorResponse.kt
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.controller
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "에러 응답")
+data class ErrorResponse(
+    val code: String,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/balance/BalanceController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/balance/BalanceController.kt
@@ -107,7 +107,7 @@ class BalanceController {
                             ExampleObject(
                                 name = "최대 잔고 초과",
                                 value = EXCEED_MAX_BALANCE_CODE,
-                                summary = "EXCEED_MAX_BALANCE_CODE"
+                                summary = "EXCEED_MAX_BALANCE"
                             ),
                         ],
                         mediaType = "application/json",

--- a/src/main/kotlin/kr/hhplus/be/server/controller/balance/BalanceController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/balance/BalanceController.kt
@@ -1,0 +1,150 @@
+package kr.hhplus.be.server.controller.balance
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.hhplus.be.server.controller.BalanceApiErrorCode.EXCEED_MAX_BALANCE_CODE
+import kr.hhplus.be.server.controller.BalanceApiErrorCode.NOT_FOUND_BALANCE_CODE
+import kr.hhplus.be.server.controller.ErrorResponse
+import kr.hhplus.be.server.controller.UserApiErrorCode.NOT_FOUND_USER_CODE
+import kr.hhplus.be.server.controller.balance.request.ChargeApiRequest
+import kr.hhplus.be.server.controller.balance.response.UserBalanceResponse
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/balances")
+@Tag(name = "Balance API", description = "잔고 조회 및 충전 API")
+class BalanceController {
+
+    @Operation(
+        summary = "잔고 조회",
+        description = "유저 ID를 기반으로 현재 잔고 조회"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "잔고 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = UserBalanceResponse::class,
+                            description = "잔고 조회 성공"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "찾을 수 없는 유저",
+                                value = NOT_FOUND_USER_CODE,
+                                summary = "NOT_FOUND_USER"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+        ]
+    )
+    @GetMapping
+    fun getUserBalance(
+        @Parameter(description = "유저 ID", required = true, example = "1")
+        @RequestParam userId: Long,
+    ): UserBalanceResponse =
+        UserBalanceResponse(
+            id = 1L,
+            userId = userId,
+            balance = 1000.0.toBigDecimal(),
+            createdAt = Instant.now(),
+            updatedAt = Instant.now()
+        )
+
+    @Operation(
+        summary = "잔고 충전",
+        description = "잔고를 충전함"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "잔고 충전 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = UserBalanceResponse::class,
+                            description = "잔고 조회 성공"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "최대 잔고 초과",
+                                value = EXCEED_MAX_BALANCE_CODE,
+                                summary = "EXCEED_MAX_BALANCE_CODE"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "찾을 수 없는 잔고",
+                                value = NOT_FOUND_BALANCE_CODE,
+                                summary = "NOT_FOUND_BALANCE"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+        ]
+    )
+    @PostMapping("/{balanceId}:charge")
+    fun charge(
+        @PathVariable balanceId: Long,
+        @Parameter(description = "잔고 ID", required = true, example = "1")
+        @RequestBody request: ChargeApiRequest,
+    ): UserBalanceResponse =
+        UserBalanceResponse(
+            id = 1L,
+            userId = 2L,
+            balance = 1000.0.toBigDecimal(),
+            createdAt = Instant.now(),
+            updatedAt = Instant.now()
+        )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/balance/request/ChargeApiRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/balance/request/ChargeApiRequest.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.controller.balance.request
+
+class ChargeApiRequest(
+    val amount: Long,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/balance/response/UserBalanceResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/balance/response/UserBalanceResponse.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.controller.balance.response
+
+import java.math.BigDecimal
+import java.time.Instant
+
+class UserBalanceResponse(
+    val id: Long,
+    val userId: Long,
+    val balance: BigDecimal,
+    val createdAt: Instant,
+    val updatedAt: Instant,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/coupon/CouponController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/coupon/CouponController.kt
@@ -1,0 +1,221 @@
+package kr.hhplus.be.server.controller.coupon
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.hhplus.be.server.controller.BalanceApiErrorCode.EXCEED_MAX_BALANCE_CODE
+import kr.hhplus.be.server.controller.BalanceApiErrorCode.NOT_FOUND_BALANCE_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.ALREADY_USED_COUPON_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.INVALID_STATE_COUPON_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.NOT_FOUND_COUPON_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.OUT_OF_STOCK_COUPON_CODE
+import kr.hhplus.be.server.controller.ErrorResponse
+import kr.hhplus.be.server.controller.UserApiErrorCode.NOT_FOUND_USER_CODE
+import kr.hhplus.be.server.controller.balance.request.ChargeApiRequest
+import kr.hhplus.be.server.controller.balance.response.UserBalanceResponse
+import kr.hhplus.be.server.controller.coupon.request.IssueCouponRequest
+import kr.hhplus.be.server.controller.coupon.response.CouponsResponse
+import kr.hhplus.be.server.controller.coupon.response.CouponsResponse.CouponResponse
+import kr.hhplus.be.server.controller.coupon.response.UserCouponResponse
+import kr.hhplus.be.server.controller.coupon.response.UserCouponsResponse
+import kr.hhplus.be.server.model.coupon.CouponType
+import org.springframework.web.bind.annotation.*
+import java.math.BigDecimal
+import java.time.Instant
+
+
+@RestController
+@Tag(name = "Coupon API", description = "쿠폰 관련 API")
+class CouponController {
+
+    @Operation(
+        summary = "쿠폰 조회",
+        description = "발급 가능한 쿠폰 목록이 조회된다 (발급 전)"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "쿠폰 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = CouponsResponse::class,
+                        )
+                    )
+                ]
+            ),
+        ]
+    )
+    @GetMapping("/coupons")
+    fun getCoupons(
+    ): CouponsResponse =
+        CouponsResponse(
+            coupons = listOf(
+                CouponResponse(
+                    id = 1L,
+                    name = "쿠폰1",
+                    type = CouponType.FIXED_AMOUNT,
+                    quantity = 10,
+                    maxDiscountAmount = BigDecimal.valueOf(10_000),
+                    discountRate = null,
+                    discountAmount = BigDecimal.valueOf(1_000),
+                    usableFrom = Instant.parse("2023-01-01T00:00:00Z"),
+                    usableTo = Instant.parse("2025-12-31T23:59:59Z"),
+                ),
+            )
+        )
+
+    @Operation(
+        summary = "유저 쿠폰 조회",
+        description = "유저의 쿠폰 목록이 조회된다 (발급 후)"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "쿠폰 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = UserCouponsResponse::class,
+                        )
+                    )
+                ]
+            ),
+        ]
+    )
+    @GetMapping("/user/{userId}/coupons")
+    fun getUserCoupons(
+        @PathVariable userId: Long,
+    ): UserCouponsResponse =
+        UserCouponsResponse(
+            coupons = listOf(
+                UserCouponResponse(
+                    id = 1L,
+                    userId = userId,
+                    coupon = CouponResponse(
+                        id = 1L,
+                        name = "쿠폰1",
+                        type = CouponType.FIXED_AMOUNT,
+                        quantity = 10,
+                        maxDiscountAmount = BigDecimal.valueOf(10_000),
+                        discountRate = null,
+                        discountAmount = BigDecimal.valueOf(1_000),
+                        usableFrom = Instant.parse("2023-01-01T00:00:00Z"),
+                        usableTo = Instant.parse("2025-12-31T23:59:59Z"),
+                    ),
+                )
+            )
+        )
+
+    @Operation(
+        summary = "쿠폰 발급",
+        description = "쿠폰을 발급함"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "쿠폰 발급 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = UserCouponResponse::class,
+                            description = "발급된 유저 쿠폰"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "쿠폰 재고 소진",
+                                value = OUT_OF_STOCK_COUPON_CODE,
+                                summary = "OUT_OF_STOCK_COUPON"
+                            ),
+                            ExampleObject(
+                                name = "발급할 수 없는 쿠폰",
+                                value = INVALID_STATE_COUPON_CODE,
+                                summary = "INVALID_STATE_COUPON"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "찾을 수 없는 쿠폰",
+                                value = NOT_FOUND_COUPON_CODE,
+                                summary = "NOT_FOUND_COUPON"
+                            ),
+                             ExampleObject(
+                                name = "찾을 수 없는 유저",
+                                value = NOT_FOUND_USER_CODE,
+                                summary = "NOT_FOUND_USER"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "409",
+                description = "요청이 현재 상태와 충돌",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "이미 발급된 쿠폰",
+                                value = ALREADY_USED_COUPON_CODE,
+                                summary = "ALREADY_HAS_COUPON"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+        ]
+    )
+    @PostMapping("/coupons:issue")
+    fun issueCoupon(
+        @RequestBody request: IssueCouponRequest,
+    ): UserCouponResponse =
+        UserCouponResponse(
+            id = 1L,
+            userId = 2L,
+            coupon = CouponResponse(
+                id = 1L,
+                name = "쿠폰1",
+                type = CouponType.FIXED_AMOUNT,
+                quantity = 10,
+                maxDiscountAmount = BigDecimal.valueOf(10_000),
+                discountRate = null,
+                discountAmount = BigDecimal.valueOf(1_000),
+                usableFrom = Instant.parse("2023-01-01T00:00:00Z"),
+                usableTo = Instant.parse("2025-12-31T23:59:59Z"),
+            ),
+        )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/coupon/request/IssueCouponRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/coupon/request/IssueCouponRequest.kt
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.controller.coupon.request
+
+class IssueCouponRequest(
+    val userId: Long,
+    val couponId: Long,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/CouponsResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/CouponsResponse.kt
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.controller.coupon.response
+
+import kr.hhplus.be.server.model.coupon.CouponType
+import java.math.BigDecimal
+import java.time.Instant
+
+class CouponsResponse(
+    val coupons: List<CouponResponse>,
+) {
+    data class CouponResponse(
+        val id: Long,
+        val name: String,
+        val type: CouponType,
+        val quantity: Int,
+        val maxDiscountAmount: BigDecimal,
+        val discountAmount: BigDecimal?,
+        val discountRate: BigDecimal?,
+        val usableFrom: Instant,
+        val usableTo: Instant,
+    )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/UserCouponResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/UserCouponResponse.kt
@@ -1,0 +1,7 @@
+package kr.hhplus.be.server.controller.coupon.response
+
+class UserCouponResponse(
+    val id: Long,
+    val userId: Long,
+    val coupon: CouponsResponse.CouponResponse,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/UserCouponsResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/coupon/response/UserCouponsResponse.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.controller.coupon.response
+
+class UserCouponsResponse(
+    val coupons: List<UserCouponResponse>
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/order/OrderController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/order/OrderController.kt
@@ -1,0 +1,107 @@
+package kr.hhplus.be.server.controller.order
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.hhplus.be.server.controller.ErrorResponse
+import kr.hhplus.be.server.controller.OrderErrorCode.INVALID_ORDER_PRICE_CODE
+import kr.hhplus.be.server.controller.OrderErrorCode.OUT_OF_PRODUCT_STOCK_CODE
+import kr.hhplus.be.server.controller.UserApiErrorCode.NOT_FOUND_USER_CODE
+import kr.hhplus.be.server.controller.order.reqeust.OrderRequest
+import kr.hhplus.be.server.controller.order.response.OrderResponse
+import kr.hhplus.be.server.model.order.OrderStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/orders")
+@Tag(name = "Order API", description = "주문 관련 API")
+class OrderController {
+
+    @Operation(
+        summary = "주문",
+        description = "주문을 시작함"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "주문 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = OrderResponse::class,
+                            description = "주문 성공"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "잘못된 주문 가격",
+                                value = INVALID_ORDER_PRICE_CODE,
+                                summary = "INVALID_ORDER_PRICE"
+                            ),
+                            ExampleObject(
+                                name = "상품 재고 부족",
+                                value = OUT_OF_PRODUCT_STOCK_CODE,
+                                summary = "OUT_OF_PRODUCT_STOCK"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "찾을 수 없는 유저",
+                                value = NOT_FOUND_USER_CODE,
+                                summary = "NOT_FOUND_USER"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+        ]
+    )
+    @PostMapping("")
+    fun charge(
+        @RequestBody request: OrderRequest,
+    ): OrderResponse =
+        OrderResponse(
+            id = 1L,
+            userId = request.userId,
+            totalPrice = request.totalPrice,
+            status = OrderStatus.READY,
+            expiresAt = Instant.now().plusSeconds(60),
+            orderItems = request.orderItems.map {
+                OrderResponse.OrderItem(
+                    productId = it.productId,
+                    quantity = it.quantity,
+                    price = it.price,
+                )
+            },
+            createdAt = Instant.now(),
+        )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/order/reqeust/OrderRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/order/reqeust/OrderRequest.kt
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.controller.order.reqeust
+
+import java.math.BigDecimal
+
+class OrderRequest(
+    val userId: Long,
+    val orderItems: List<OrderItem>,
+    val totalPrice: BigDecimal,
+) {
+    data class OrderItem(
+        val productId: Long,
+        val quantity: Int,
+        val price: BigDecimal,
+    )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/order/response/OrderResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/order/response/OrderResponse.kt
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.controller.order.response
+
+import kr.hhplus.be.server.model.order.OrderStatus
+import java.math.BigDecimal
+import java.time.Instant
+
+class OrderResponse(
+    val id: Long,
+    val userId: Long,
+    val status: OrderStatus,
+    val totalPrice: BigDecimal,
+    val expiresAt: Instant,
+    val orderItems: List<OrderItem>,
+    val createdAt: Instant,
+) {
+    data class OrderItem(
+        val productId: Long,
+        val quantity: Int,
+        val price: BigDecimal,
+    )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/payment/PaymentController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/payment/PaymentController.kt
@@ -1,0 +1,138 @@
+package kr.hhplus.be.server.controller.payment
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.ExampleObject
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.hhplus.be.server.controller.CouponErrorCode.ALREADY_USED_COUPON_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.EXPIRED_COUPON_CODE
+import kr.hhplus.be.server.controller.CouponErrorCode.NOT_FOUND_COUPON_CODE
+import kr.hhplus.be.server.controller.ErrorResponse
+import kr.hhplus.be.server.controller.OrderErrorCode.ALREADY_PAID_ORDER_CODE
+import kr.hhplus.be.server.controller.OrderErrorCode.EXPIRED_ORDER_CODE
+import kr.hhplus.be.server.controller.OrderErrorCode.INVALID_ORDER_PRICE_CODE
+import kr.hhplus.be.server.controller.OrderErrorCode.NOT_FOUND_ORDER_CODE
+import kr.hhplus.be.server.controller.OrderErrorCode.OUT_OF_PRODUCT_STOCK_CODE
+import kr.hhplus.be.server.controller.UserApiErrorCode.NOT_FOUND_USER_CODE
+import kr.hhplus.be.server.controller.order.reqeust.OrderRequest
+import kr.hhplus.be.server.controller.order.response.OrderResponse
+import kr.hhplus.be.server.controller.payment.requeset.PayRequest
+import kr.hhplus.be.server.controller.payment.respnse.PaymentResponse
+import kr.hhplus.be.server.model.order.OrderStatus
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/payments")
+@Tag(name = "Payment API", description = "결제 관련 API")
+class PaymentController {
+    @Operation(
+        summary = "결제",
+        description = "결제 진행"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "결제 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = PaymentResponse::class,
+                            description = "결제 성공"
+                        )
+                    )
+                ]
+            ),
+            ApiResponse(
+                responseCode = "400",
+                description = "잘못된 요청",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "잘못된 가격(결제 금액오류)",
+                                value = INVALID_ORDER_PRICE_CODE,
+                                summary = "INVALID_ORDER_PRICE"
+                            ),
+                            ExampleObject(
+                                name = "이미 결제된 주문",
+                                value = ALREADY_PAID_ORDER_CODE,
+                                summary = "ALREADY_PAID_ORDER"
+                            ),
+                            ExampleObject(
+                                name = "만료된 주문",
+                                value = EXPIRED_ORDER_CODE,
+                                summary = "EXPIRED_ORDER_CODE"
+                            ),
+                            ExampleObject(
+                                name = "상품 재고 부족",
+                                value = OUT_OF_PRODUCT_STOCK_CODE,
+                                summary = "OUT_OF_PRODUCT_STOCK"
+                            ),
+                            ExampleObject(
+                                name = "이미 사용된 쿠폰",
+                                value = ALREADY_USED_COUPON_CODE,
+                                summary = "ALREADY_USED_COUPON"
+                            ),
+                            ExampleObject(
+                                name = "만료된 쿠폰",
+                                value = EXPIRED_COUPON_CODE,
+                                summary = "EXPIRED_COUPON_CODE"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "리소스를 찾을 수 없음",
+                content = [
+                    Content(
+                        examples = [
+                            ExampleObject(
+                                name = "찾을 수 없는 유저",
+                                value = NOT_FOUND_USER_CODE,
+                                summary = "NOT_FOUND_USER"
+                            ),
+                            ExampleObject(
+                                name = "찾을 수 없는 주문",
+                                value = NOT_FOUND_ORDER_CODE,
+                                summary = "NOT_FOUND_ORDER"
+                            ),
+                            ExampleObject(
+                                name = "찾을 수 없는 쿠폰",
+                                value = NOT_FOUND_COUPON_CODE,
+                                summary = "NOT_FOUND_COUPON"
+                            ),
+                        ],
+                        mediaType = "application/json",
+                        schema = Schema(implementation = ErrorResponse::class)
+                    ),
+                ]
+            ),
+        ]
+    )
+    @PostMapping("")
+    fun pay(
+        @RequestBody request: PayRequest,
+    ): PaymentResponse =
+        PaymentResponse(
+            id = 1L,
+            orderId = request.orderId,
+            userId = request.userId,
+            couponId = request.couponId,
+            originalAmount = request.originalAmount,
+            discountAmount = request.discountAmount,
+            finalAmount = request.finalAmount,
+        )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/payment/PaymentController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/payment/PaymentController.kt
@@ -17,16 +17,12 @@ import kr.hhplus.be.server.controller.OrderErrorCode.INVALID_ORDER_PRICE_CODE
 import kr.hhplus.be.server.controller.OrderErrorCode.NOT_FOUND_ORDER_CODE
 import kr.hhplus.be.server.controller.OrderErrorCode.OUT_OF_PRODUCT_STOCK_CODE
 import kr.hhplus.be.server.controller.UserApiErrorCode.NOT_FOUND_USER_CODE
-import kr.hhplus.be.server.controller.order.reqeust.OrderRequest
-import kr.hhplus.be.server.controller.order.response.OrderResponse
 import kr.hhplus.be.server.controller.payment.requeset.PayRequest
 import kr.hhplus.be.server.controller.payment.respnse.PaymentResponse
-import kr.hhplus.be.server.model.order.OrderStatus
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
-import java.time.Instant
 
 @RestController
 @RequestMapping("/payments")

--- a/src/main/kotlin/kr/hhplus/be/server/controller/payment/requeset/PayRequest.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/payment/requeset/PayRequest.kt
@@ -1,0 +1,12 @@
+package kr.hhplus.be.server.controller.payment.requeset
+
+import java.math.BigDecimal
+
+class PayRequest(
+    val userId: Long,
+    val orderId: Long,
+    val couponId: Long?,
+    val originalAmount: BigDecimal,
+    val discountAmount: BigDecimal,
+    val finalAmount: BigDecimal,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/payment/respnse/PaymentResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/payment/respnse/PaymentResponse.kt
@@ -1,0 +1,13 @@
+package kr.hhplus.be.server.controller.payment.respnse
+
+import java.math.BigDecimal
+
+class PaymentResponse(
+    val id: Long,
+    val userId: Long,
+    val orderId: Long,
+    val couponId: Long?,
+    val originalAmount: BigDecimal,
+    val discountAmount: BigDecimal,
+    val finalAmount: BigDecimal,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/product/ProductController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/product/ProductController.kt
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 import java.time.Instant
 
 @RestController
-@RequestMapping("/products")
 @Tag(name = "Product API", description = "상품 관련 API")
 class ProductController {
 
@@ -40,7 +39,7 @@ class ProductController {
             ),
         ]
     )
-    @GetMapping
+    @GetMapping("/products")
     fun getProducts(): ProductsResponse = ProductsResponse(
         products = listOf(
             ProductResponse(
@@ -63,4 +62,50 @@ class ProductController {
             )
         )
     )
+
+
+    @Operation(
+        summary = "인기 상품 조회",
+        description = "3일간 판매량이 높은 5개의 상품 조회, 제일 많이 팔린 순으로 반환"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "인기 상품 목록 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = ProductsResponse::class,
+                        )
+                    )
+                ]
+            ),
+        ]
+    )
+    @GetMapping("/products:popular")
+    fun getPopularProducts(): ProductsResponse = ProductsResponse(
+        products = listOf(
+            ProductResponse(
+                id = 1L,
+                status = ProductStatus.ON_SALE,
+                name = "상품1",
+                description = "상품1 설명",
+                price = 10000,
+                stock = 10,
+                createdAt = Instant.now(),
+            ),
+            ProductResponse(
+                id = 2L,
+                status = ProductStatus.ON_SALE,
+                name = "상품2",
+                description = "상품2 설명",
+                price = 20000,
+                stock = 20,
+                createdAt = Instant.now(),
+            )
+        )
+    )
+
 }

--- a/src/main/kotlin/kr/hhplus/be/server/controller/product/ProductController.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/product/ProductController.kt
@@ -1,0 +1,66 @@
+package kr.hhplus.be.server.controller.product
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import kr.hhplus.be.server.controller.product.response.ProductResponse
+import kr.hhplus.be.server.controller.product.response.ProductsResponse
+import kr.hhplus.be.server.model.product.ProductStatus
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.time.Instant
+
+@RestController
+@RequestMapping("/products")
+@Tag(name = "Product API", description = "상품 관련 API")
+class ProductController {
+
+    @Operation(
+        summary = "상품 조회",
+        description = "판매 중인 상품 목록 조회"
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(
+                responseCode = "200",
+                description = "상품 목록 조회 성공",
+                content = [
+                    Content(
+                        mediaType = "application/json",
+                        schema = Schema(
+                            implementation = ProductsResponse::class,
+                        )
+                    )
+                ]
+            ),
+        ]
+    )
+    @GetMapping
+    fun getProducts(): ProductsResponse = ProductsResponse(
+        products = listOf(
+            ProductResponse(
+                id = 1L,
+                status = ProductStatus.ON_SALE,
+                name = "상품1",
+                description = "상품1 설명",
+                price = 10000,
+                stock = 10,
+                createdAt = Instant.now(),
+            ),
+            ProductResponse(
+                id = 2L,
+                status = ProductStatus.ON_SALE,
+                name = "상품2",
+                description = "상품2 설명",
+                price = 20000,
+                stock = 20,
+                createdAt = Instant.now(),
+            )
+        )
+    )
+}

--- a/src/main/kotlin/kr/hhplus/be/server/controller/product/response/ProductResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/product/response/ProductResponse.kt
@@ -1,0 +1,14 @@
+package kr.hhplus.be.server.controller.product.response
+
+import kr.hhplus.be.server.model.product.ProductStatus
+import java.time.Instant
+
+class ProductResponse(
+    val id: Long,
+    val status: ProductStatus,
+    val name: String,
+    val description: String,
+    val price: Long,
+    val stock: Long,
+    val createdAt: Instant,
+)

--- a/src/main/kotlin/kr/hhplus/be/server/controller/product/response/ProductsResponse.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/controller/product/response/ProductsResponse.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.controller.product.response
+
+class ProductsResponse(
+    val products: List<ProductResponse>
+)

--- a/src/main/kotlin/kr/hhplus/be/server/model/coupon/CouponType.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/model/coupon/CouponType.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.model.coupon
+
+enum class CouponType {
+    FIXED_AMOUNT, PERCENTAGE;
+}

--- a/src/main/kotlin/kr/hhplus/be/server/model/order/OrderStatus.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/model/order/OrderStatus.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.model.order
+
+enum class OrderStatus {
+    READY, STOCK_ALLOCATED, STOCK_ALLOCATION_FAILED, PAID, PAYMENT_FAILED, DELIVERED, DELIVERY_FAILED, COMPLETED
+}

--- a/src/main/kotlin/kr/hhplus/be/server/model/product/ProductStatus.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/model/product/ProductStatus.kt
@@ -1,0 +1,5 @@
+package kr.hhplus.be.server.model.product
+
+enum class ProductStatus {
+    INACTIVE, ON_SALE;
+}


### PR DESCRIPTION
### **커밋 링크**

swagger설정 추가 : 6a4b8e04ead1439f0e892d85bb00622e9b927a67
잔고 충전/조회 API 스펙 : f2ee955baa71a7d6ed87173d538b2493b0492af1
상품 목록 조회 API 스펙: abf1b41f88c0c32f04f9f00bb288e573c52fa2f7
주문 API 스펙: f5ad64f71d7a59ad6d899b630a655918e36cc721
결제 API 스펙: 6c9b07dfef515247062c6adcd6ae0ba16cebd2dc
쿠폰 발급/조회 API 스펙 : 3f82aa9fd4696d713e3e4a4d726f689669ade97c
인기상품 조회 API 스펙 : 815e8e3ffaeb31fe8021cf3f13fd014c14d73009

---
### **리뷰 포인트(질문)**
- 충전 API인 경우, POST /balances 를 잔고를 수정하는 의미고, 추가랑은 달라 커스텀 메서드를 사용했습니다(/balances:custom)
  -  도메인을 드러내는 규칙을 지키면서도, 이렇게 충전, 쿠폰에 대한 path 는 어떻게 지정하는지 궁금합니다.  
  - [커스텀메서드](https://cloud.google.com/apis/design/custom_methods?hl=ko)
-  인기 있는 상품을 조회하는 것이지만, 단순히 게시글 조회 url에 필터링을 걸기에는, 3일 간의 인기있던 5개의 상품을 조회하는 조건이 있는 등, 특별한 요청이라 생각되어 url 을 분리했습니다(/posts, /posts:popular). 이런 경우에 분리하는 것이 맞을지 검토 부탁드립니다. 

---
### **이번주 KPT 회고**

### Keep
학습을 꾸준히 했다 

### Problem
시간에 임박해서야 제출 할 수 있었다. 

### Try
시간 확보를 더 잘하자 
